### PR TITLE
Add fix so Safari displays events on the flyer

### DIFF
--- a/app/flyer/flyer.js
+++ b/app/flyer/flyer.js
@@ -46,7 +46,12 @@ function ($scope, $routeParams, $filter, eventquery) {
         var result = [];
 
         for (var i = 0; i < $scope.events.length ; i++) {
-            var event_date = new Date($scope.events[i].start_time);
+            var start_time = $scope.events[i].start_time;
+
+            // start_time as returned by FB Graph API isn't ISO 8601 compliant
+            // make it so by adding the requiste colon in the timezone
+            var event_date = new Date(start_time.slice(0,22) + ':' + start_time.slice(22));
+
             if (event_date > df && event_date < dt){
                 $scope.events[i].short_desc = $scope.events[i].description.split("\n")[0];
                 $scope.events[i].venue = eventquery.getCoworkingVenue($scope.events[i]);


### PR DESCRIPTION
The event start_time field returned from the Facebook Graph API is not
compliant with ISO 8601 - it is missing a colon in the timezone field.
Safari is (evidently) more strict about date string formats, so this
fixes the strings local to the flyer.

The events now display correctly in Safari on OS X and iOS.
