### PR TITLE
Fix SVG rendering incorrect size issue in Safari.

### DIFF
--- a/app/views/flyer.html
+++ b/app/views/flyer.html
@@ -18,7 +18,7 @@
   	<div class="container-fluid">
       <div class="row organizer-row">
         <a class="organizer-credit-link col-xs-12 col-sm-6 col-md-5" href="http://openhsv.com" target="_blank">
-          <svg class="organizer-graphic" xmlns="http://www.w3.org/2000/svg" width="799.674" height="219.628" viewBox="0 0 799.674 219.628">
+          <svg class="organizer-graphic" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 799.674 219.628">
             <path class="fill-secondary" ng-class="fillsecondary" fill="#555" d="M0 181.655l210.173 37.973 589.5-37.973V0H95.137L0 45.69"/>
             <path opacity=".3" d="M95.136 181.655V0L0 45.69V173.53"/>
             <path opacity=".5" d="M0 181.655v-8.123l95.136 8.123h704.538l-589.5 37.973"/>


### PR DESCRIPTION
The SVG height is calculated incorrectly in Safari on mobile and desktop. This commit fixes it.

Tested all responsive sizes in Safari desktop and mobile, Firefox, and Chrome.

Reference: http://dontwakemeup.com/webkit-svg-height-bug-workaround/
