### PR TITLE
Minor change to the version numbers

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "coworkal",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "dependencies": {
     "angular": "^1.4.0",
     "tether": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "flyer",
   "private": true,
+  "version": "1.0.0",
   "devDependencies": {
     "autoprefixer-core": "^5.2.1",
     "grunt": "^0.4.5",


### PR DESCRIPTION
When I would run bower install it kept hanging up. By adding a version number to package.json it fixed this issue. I'm not sure if it has to do with the version of Bower I'm running or not. 

While I was at it I went ahead and updated the bower.json version number so that it matches the new package.json version number.
